### PR TITLE
Fix PluginManager version check by discarding patch rel from version string

### DIFF
--- a/IPA.Loader/Loader/PluginManager.cs
+++ b/IPA.Loader/Loader/PluginManager.cs
@@ -294,7 +294,7 @@ namespace IPA.Loader
             string pluginDir = BeatSaber.PluginsPath;
             var gameVer = BeatSaber.GameVersion;
             var lastVerS = SelfConfig.SelfConfigRef.Value.LastGameVersion;
-            var lastVer = lastVerS != null ? new SemVer.Version(lastVerS) : null;
+            var lastVer = lastVerS != null ? new SemVer.Version(lastVerS.Split('p').First()) : null;
 
             if (lastVer != null && gameVer != lastVer)
             {


### PR DESCRIPTION
Versions like 1.1.0p1 break `SemVer.Version`. This commit fixes that by discarding the patch version, leaving e.g. 1.1.0.

This fixes https://github.com/beat-saber-modding-group/BeatSaber-IPA-Reloaded/issues/14