### PR TITLE
Virtualizer fix

### DIFF
--- a/IPA.Injector/Virtualizer.cs
+++ b/IPA.Injector/Virtualizer.cs
@@ -103,7 +103,7 @@ namespace IPA.Injector
                 if (method.IsManaged
                     && method.IsIL
                     && !method.IsStatic
-                    && !method.IsVirtual
+                    && (!method.IsVirtual || method.IsFinal)
                     && !method.IsAbstract
                     && !method.IsAddOn
                     && !method.IsConstructor
@@ -128,6 +128,7 @@ namespace IPA.Injector
                     }
 
                     method.IsVirtual = true;
+                    method.IsFinal = false;
                     method.IsPublic = true;
                     method.IsPrivate = false;
                     method.IsNewSlot = true;

--- a/IPA.Injector/Virtualizer.cs
+++ b/IPA.Injector/Virtualizer.cs
@@ -70,7 +70,7 @@ namespace IPA.Injector
         }
 
         private TypeReference inModreqRef;
-        private TypeReference outModreqRef;
+        //private TypeReference outModreqRef;
 
         private void VirtualizeType(TypeDefinition type)
         {
@@ -119,11 +119,12 @@ namespace IPA.Injector
                             inModreqRef ??= module.ImportReference(typeof(System.Runtime.InteropServices.InAttribute));
                             param.ParameterType = AddModreqIfNotExist(param.ParameterType, inModreqRef);
                         }
-                        if (param.IsOut)
-                        {
-                            outModreqRef ??= module.ImportReference(typeof(System.Runtime.InteropServices.OutAttribute));
-                            param.ParameterType = AddModreqIfNotExist(param.ParameterType, outModreqRef);
-                        }
+                        // Breaks override methods if modreq is applied to `out` parameters
+                        //if (param.IsOut)
+                        //{
+                        //    outModreqRef ??= module.ImportReference(typeof(System.Runtime.InteropServices.OutAttribute));
+                        //    param.ParameterType = AddModreqIfNotExist(param.ParameterType, outModreqRef);
+                        //}
                     }
 
                     method.IsVirtual = true;


### PR DESCRIPTION
* Removes modreq from `out` parameters.
* Virtualizes methods that were virtual and final (because they are interface methods?)