### PR TITLE
Clear nuget locals before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           # As usual, obtained from: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json
           dotnet-version: "3.1.404" # since we now use this
+      - name: Clean
+        run: dotnet nuget locals all --clear
       - name: Restore
         run: msbuild -t:Restore -m
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           # As usual, obtained from: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json
           dotnet-version: "3.1.404" # since we now use this
-      - name: Clean
+      - name: Clear Nuget Cache
         run: dotnet nuget locals all --clear
       - name: Restore
         run: msbuild -t:Restore -m

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           # As usual, obtained from: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json
           dotnet-version: "3.1.404" # since we now use this
+      - name: Clear Nuget Cache
+        run: dotnet nuget locals all --clear
       - name: Nuget Restore
         run: msbuild -t:Restore -m
       - name: Install DocFX

--- a/.github/workflows/tag_docs.yml
+++ b/.github/workflows/tag_docs.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           # As usual, obtained from: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json
           dotnet-version: "3.1.404" # since we now use this
+      - name: Clear Nuget Cache
+        run: dotnet nuget locals all --clear
       - name: Nuget Restore
         run: msbuild -t:Restore -m
       - name: Install DocFX


### PR DESCRIPTION
Fixes the GitHub Actions build by adding this stop before restore and build:
```yaml
      - name: Clean
        run: dotnet nuget locals all --clear
```