### PR TITLE
Check if mono debugger is already initialized

### DIFF
--- a/Doorstop/Proxy/main.c
+++ b/Doorstop/Proxy/main.c
@@ -111,6 +111,13 @@ void unhandledException(void* exc, void* data)
 // We use this since it will always be called once to initialize Mono's JIT
 void *ownMonoJitInitVersion(const char *root_domain_name, const char *runtime_version)
 {
+	const BOOL debugger_already_initialized = mono_debug_enabled();
+
+	if(debugger_already_initialized)
+	{
+		LOG("Debugger was already initialized\n");
+	}
+	
 	// Call the original mono_jit_init_version to initialize the Unity Root Domain
 	if (debug) {
 		char* opts[1];
@@ -118,14 +125,14 @@ void *ownMonoJitInitVersion(const char *root_domain_name, const char *runtime_ve
 		ownMonoJitParseOptions(0, opts);
 	}
 #ifdef WIN32
-    if (debug_info) {
+    if (debug_info && !debugger_already_initialized) {
         mono_debug_init(MONO_DEBUG_FORMAT_MONO);
     }
 #endif
 
 	void *domain = mono_jit_init_version(root_domain_name, runtime_version);
 
-	if (debug_info) {
+	if (debug_info && !debugger_already_initialized) {
 #ifdef WIN64
         mono_debug_init(MONO_DEBUG_FORMAT_MONO);
 #endif

--- a/Doorstop/Proxy/mono.h
+++ b/Doorstop/Proxy/mono.h
@@ -40,6 +40,7 @@ typedef enum {
 
 void (*mono_jit_parse_options)(int argc, char * argv[]);
 void (*mono_debug_init)(MonoDebugFormat format);
+BOOL (*mono_debug_enabled)(void);
 void (*mono_debug_domain_create)(void*);
 
 void *(*mono_jit_init_version)(const char *root_domain_name, const char *runtime_version);
@@ -90,6 +91,7 @@ inline void loadMonoFunctions(HMODULE monoLib)
 	GET_MONO_PROC(mono_assembly_get_image);
 	GET_MONO_PROC(mono_runtime_invoke);
 	GET_MONO_PROC(mono_debug_init);
+	GET_MONO_PROC(mono_debug_enabled);
 	GET_MONO_PROC(mono_jit_init_version);
 	GET_MONO_PROC(mono_jit_parse_options);
 	GET_MONO_PROC(mono_method_desc_new);


### PR DESCRIPTION
When trying to initialize the mono debugger more than once unity will crash. This is an issue with for example Beat Saber 1.29.4 where the debugger is already enabled by default. The `--debug` flag and thus also the `--mono-debug` flag will crash the game. This PR checks if the mono debugger has already been initialized.