### PR TITLE
Fix hard crash when using debug builds

### DIFF
--- a/IPA.Loader/Loader/PluginComponent.cs
+++ b/IPA.Loader/Loader/PluginComponent.cs
@@ -59,7 +59,7 @@ namespace IPA.Loader
                 initialized = true;
 
 #if DEBUG
-                Config.Stores.GeneratedStoreImpl.DebugSaveAssembly("GeneratedAssembly.dll");
+                Config.Stores.GeneratedStoreImpl.DebugSaveAssembly($"{Config.Stores.GeneratedStoreImpl.GeneratedAssemblyName}.dll");
 #endif
             }
         }


### PR DESCRIPTION
Mono has suddenly decided it doesn't want to save the generated config assembly to a separate file. Not quite sure why that's the case, but this fixes it for now.